### PR TITLE
Use correct interface name while configuring peers

### DIFF
--- a/wg-ip
+++ b/wg-ip
@@ -521,7 +521,7 @@ dryrun_iface(){
 		[ "$allowed_ips" = "(none)" ] && allowed_ips=""
 		allowed_ips="$allowed_ips $peer_ip/$ipbits"
 		allowed_ips="$(echo $allowed_ips | tr ' ' ',')"
-		echo "wg set wg0 peer $peer_pubkey allowed-ips $allowed_ips"
+		echo "wg set $iface peer $peer_pubkey allowed-ips $allowed_ips"
 	done
 }
 


### PR DESCRIPTION
The interface name is hardcoded as `wg0` here, should use the `$iface` variable instead.